### PR TITLE
This commit adds a significant number of unit tests to the project, i…

### DIFF
--- a/tests/unit/test_http_api.py
+++ b/tests/unit/test_http_api.py
@@ -21,3 +21,112 @@ def test_get_tables(monkeypatch):
     response = client.get("/api/schema/tables")
     assert response.status_code == 200
     assert response.json() == ["foo"]
+
+def test_get_table_schema_found(monkeypatch):
+    test_schema = {"tables": {"foo": {"columns": ["col1"]}}, "views": {}, "relationships": []}
+    monkeypatch.setattr("app.http_api.db.get_database_schema", lambda: test_schema)
+    response = client.get("/api/schema/tables/foo")
+    assert response.status_code == 200
+    assert response.json() == {"columns": ["col1"]}
+
+def test_get_table_schema_not_found(monkeypatch):
+    test_schema = {"tables": {}, "views": {}, "relationships": []}
+    monkeypatch.setattr("app.http_api.db.get_database_schema", lambda: test_schema)
+    response = client.get("/api/schema/tables/foo")
+    assert response.status_code == 404
+
+def test_get_views(monkeypatch):
+    test_schema = {"tables": {}, "views": {"bar": {}}, "relationships": []}
+    monkeypatch.setattr("app.http_api.db.get_database_schema", lambda: test_schema)
+    response = client.get("/api/schema/views")
+    assert response.status_code == 200
+    assert response.json() == ["bar"]
+
+def test_get_view_schema_found(monkeypatch):
+    test_schema = {"tables": {}, "views": {"bar": {"columns": ["col1"]}}, "relationships": []}
+    monkeypatch.setattr("app.http_api.db.get_database_schema", lambda: test_schema)
+    response = client.get("/api/schema/views/bar")
+    assert response.status_code == 200
+    assert response.json() == {"columns": ["col1"]}
+
+def test_get_view_schema_not_found(monkeypatch):
+    test_schema = {"tables": {}, "views": {}, "relationships": []}
+    monkeypatch.setattr("app.http_api.db.get_database_schema", lambda: test_schema)
+    response = client.get("/api/schema/views/bar")
+    assert response.status_code == 404
+
+def test_get_relationships(monkeypatch):
+    test_relationships = [{"from": "table1", "to": "table2"}]
+    test_schema = {"tables": {}, "views": {}, "relationships": test_relationships}
+    monkeypatch.setattr("app.http_api.db.get_database_schema", lambda: test_schema)
+    response = client.get("/api/schema/relationships")
+    assert response.status_code == 200
+    assert response.json() == test_relationships
+
+def test_post_query_success(monkeypatch):
+    monkeypatch.setattr("app.http_api.db.execute_query", lambda query: {"result": "ok"})
+    response = client.post("/api/query", json={"query": "SELECT 1"})
+    assert response.status_code == 200
+    assert response.json() == {"result": "ok"}
+
+def test_post_query_missing_query(monkeypatch):
+    response = client.post("/api/query", json={})
+    assert response.status_code == 400
+
+def test_post_query_db_error(monkeypatch):
+    def mock_execute_query(query):
+        raise ValueError("DB Error")
+    monkeypatch.setattr("app.http_api.db.execute_query", mock_execute_query)
+    response = client.post("/api/query", json={"query": "SELECT 1"})
+    assert response.status_code == 400
+    assert "DB Error" in response.json()["detail"]
+
+def test_refresh_schema(monkeypatch):
+    def mock_refresh():
+        # print("mock_refresh called")
+        pass
+    monkeypatch.setattr("app.http_api.db.refresh_schema_cache", mock_refresh)
+    response = client.post("/api/schema/refresh")
+    assert response.status_code == 200
+    assert response.json() == {"status": "Schema cache refreshed"}
+
+def test_get_tools(monkeypatch):
+    test_tools = [{"name": "tool1", "description": "desc1", "parameters": {}}]
+    monkeypatch.setattr("app.http_api.list_all_tools", lambda mcp: test_tools)
+    response = client.get("/api/tools")
+    assert response.status_code == 200
+    assert response.json() == test_tools
+
+def test_get_tool_found(monkeypatch):
+    test_tools = [{"name": "tool1", "description": "desc1", "parameters": {}}]
+    monkeypatch.setattr("app.http_api.list_all_tools", lambda mcp: test_tools)
+    response = client.get("/api/tools/tool1")
+    assert response.status_code == 200
+    assert response.json() == test_tools[0]
+
+def test_get_tool_not_found(monkeypatch):
+    test_tools = [{"name": "tool1", "description": "desc1", "parameters": {}}]
+    monkeypatch.setattr("app.http_api.list_all_tools", lambda mcp: test_tools)
+    response = client.get("/api/tools/tool2")
+    assert response.status_code == 404
+
+def test_get_prompts(monkeypatch):
+    test_prompts = {"prompt1": {"title": "title1", "description": "desc1"}}
+    monkeypatch.setattr("app.http_api.load_prompts", lambda: test_prompts)
+    response = client.get("/api/prompts")
+    assert response.status_code == 200
+    assert response.json() == [{"name": "prompt1", "title": "title1", "description": "desc1"}]
+
+def test_get_prompt_found(monkeypatch):
+    test_template = "This is a template"
+    monkeypatch.setattr("app.http_api.get_prompt_template", lambda name: test_template)
+    response = client.get("/api/prompts/prompt1")
+    assert response.status_code == 200
+    assert response.json() == {"name": "prompt1", "template": test_template}
+
+def test_get_prompt_not_found(monkeypatch):
+    def mock_get_template(name):
+        raise KeyError
+    monkeypatch.setattr("app.http_api.get_prompt_template", mock_get_template)
+    response = client.get("/api/prompts/prompt2")
+    assert response.status_code == 404

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,0 +1,60 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from app.server import mcp
+import app.server as server_module
+
+# It's better to access the tools via the mcp instance as they are registered there
+execute_sql_tool = mcp._tool_manager._tools['execute_sql']
+get_table_sample_tool = mcp._tool_manager._tools['get_table_sample']
+refresh_schema_tool = mcp._tool_manager._tools['refresh_schema']
+
+@pytest.mark.asyncio
+async def test_execute_sql(monkeypatch):
+    # Mock the db.execute_query method
+    mock_execute = MagicMock(return_value=[{"col1": "value1"}])
+    monkeypatch.setattr(server_module.db, "execute_query", mock_execute)
+
+    # Mock the context object
+    mock_ctx = MagicMock()
+    mock_ctx.info = AsyncMock()
+
+    # Call the tool function
+    query = "SELECT * FROM test_table"
+    result = await execute_sql_tool.fn(query, mock_ctx)
+
+    # Assertions
+    mock_execute.assert_called_once_with(query)
+    mock_ctx.info.assert_awaited_once_with(f"Executing query: {query}")
+    assert result == [{"col1": "value1"}]
+
+def test_get_table_sample(monkeypatch):
+    # Mock the db.get_table_sample method
+    mock_get_sample = MagicMock(return_value=[{"col1": "sample_value"}])
+    monkeypatch.setattr(server_module.db, "get_table_sample", mock_get_sample)
+
+    # Call the tool function
+    table_name = "test_table"
+    limit = 5
+    result = get_table_sample_tool.fn(table_name, limit=limit)
+
+    # Assertions
+    mock_get_sample.assert_called_once_with(table_name, limit)
+    assert result == [{"col1": "sample_value"}]
+
+@pytest.mark.asyncio
+async def test_refresh_schema(monkeypatch):
+    # Mock the db.refresh_schema_cache method
+    mock_refresh = MagicMock()
+    monkeypatch.setattr(server_module.db, "refresh_schema_cache", mock_refresh)
+
+    # Mock the context object
+    mock_ctx = MagicMock()
+    mock_ctx.info = AsyncMock()
+
+    # Call the tool function
+    result = await refresh_schema_tool.fn(mock_ctx)
+
+    # Assertions
+    mock_refresh.assert_called_once()
+    mock_ctx.info.assert_awaited_once_with("Schema cache refreshed.")
+    assert result == "Schema cache refreshed."


### PR DESCRIPTION
…ncreasing test coverage for the HTTP API and the MCP tools.

- Expanded `tests/unit/test_http_api.py` to cover all API endpoints, including success and failure cases.
- Created `tests/unit/test_tools.py` to add unit tests for the `execute_sql`, `get_table_sample`, and `refresh_schema` tools.
- Added `pytest-asyncio` to handle testing of async functions correctly.
- Ensured the entire test suite passes.